### PR TITLE
Removing reference to logs in main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -151,24 +151,6 @@ resource "aws_elasticsearch_domain" "elasticsearch_domain" {
     automated_snapshot_start_hour = var.automated_snapshot_start_hour
   }
 
-  log_publishing_options {
-    enabled                  = var.log_publishing_index_enabled
-    log_type                 = "INDEX_SLOW_LOGS"
-    cloudwatch_log_group_arn = var.log_publishing_index_cloudwatch_log_group_arn
-  }
-
-  log_publishing_options {
-    enabled                  = var.log_publishing_search_enabled
-    log_type                 = "SEARCH_SLOW_LOGS"
-    cloudwatch_log_group_arn = var.log_publishing_search_cloudwatch_log_group_arn
-  }
-
-  log_publishing_options {
-    enabled                  = var.log_publishing_application_enabled
-    log_type                 = "ES_APPLICATION_LOGS"
-    cloudwatch_log_group_arn = var.log_publishing_application_cloudwatch_log_group_arn
-  }
-
   tags = {
     business-unit          = var.business-unit
     application            = var.application


### PR DESCRIPTION
Pipeline fails as the variables related to logs are removed from variables.tf but referenced in main.tf