### PR TITLE
Revert changes for release 3.1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -151,6 +151,24 @@ resource "aws_elasticsearch_domain" "elasticsearch_domain" {
     automated_snapshot_start_hour = var.automated_snapshot_start_hour
   }
 
+  log_publishing_options {
+    enabled                  = var.log_publishing_index_enabled
+    log_type                 = "INDEX_SLOW_LOGS"
+    cloudwatch_log_group_arn = var.log_publishing_index_cloudwatch_log_group_arn
+  }
+
+  log_publishing_options {
+    enabled                  = var.log_publishing_search_enabled
+    log_type                 = "SEARCH_SLOW_LOGS"
+    cloudwatch_log_group_arn = var.log_publishing_search_cloudwatch_log_group_arn
+  }
+
+  log_publishing_options {
+    enabled                  = var.log_publishing_application_enabled
+    log_type                 = "ES_APPLICATION_LOGS"
+    cloudwatch_log_group_arn = var.log_publishing_application_cloudwatch_log_group_arn
+  }
+
   tags = {
     business-unit          = var.business-unit
     application            = var.application

--- a/variables.tf
+++ b/variables.tf
@@ -94,6 +94,42 @@ variable "ebs_iops" {
   description = "The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type"
 }
 
+variable "log_publishing_index_enabled" {
+  type        = string
+  default     = "false"
+  description = "Specifies whether log publishing option for INDEX_SLOW_LOGS is enabled or not"
+}
+
+variable "log_publishing_search_enabled" {
+  type        = string
+  default     = "false"
+  description = "Specifies whether log publishing option for SEARCH_SLOW_LOGS is enabled or not"
+}
+
+variable "log_publishing_application_enabled" {
+  type        = string
+  default     = "false"
+  description = "Specifies whether log publishing option for ES_APPLICATION_LOGS is enabled or not"
+}
+
+variable "log_publishing_index_cloudwatch_log_group_arn" {
+  type        = string
+  default     = ""
+  description = "ARN of the CloudWatch log group to which log for INDEX_SLOW_LOGS needs to be published"
+}
+
+variable "log_publishing_search_cloudwatch_log_group_arn" {
+  type        = string
+  default     = ""
+  description = "ARN of the CloudWatch log group to which log for SEARCH_SLOW_LOGS  needs to be published"
+}
+
+variable "log_publishing_application_cloudwatch_log_group_arn" {
+  type        = string
+  default     = ""
+  description = "ARN of the CloudWatch log group to which log for ES_APPLICATION_LOGS needs to be published"
+}
+
 variable "automated_snapshot_start_hour" {
   description = "Hour at which automated snapshots are taken, in UTC"
   default     = 0


### PR DESCRIPTION
Release 3.1 was created for a single team (peoplefinder), and the only changes made were in order to maintain compatibility with an older version of ElasticSearch, which they wanted to use.

In the end, the team decided to upgrade to a newer version of ElasticSearch, so they are using version 3.0 of this module.

This means release 3.1 is unnecessary, and takes the codebase in the wrong direction.

This PR reverts all the changes made to release 3.0, so that the master branch is once more in line with the latest valid release (3.0).

Once merged, release 3.1 will be removed by running:

```
git push --delete origin 3.1
```