### PR TITLE
Allow running multiple  aws_es_proxy services in a single namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ module "example_team_es" {
 | elasticsearch-domain | The domain name of the Elasticsearch cluster to create. This will be appended with the namespace name and will look like `<team_name>-<environment-name>-<elasticsearch-domain>`  | string | | yes |
 | namespace | Namespace which will access the Elasticsearch cluster | string | | yes |
 | elasticsearch_version | Version of Elasticsearch to deploy  | string | `7.1` | no |
+| aws_es_proxy_service_name | Name to be used by aws-es-proxy service  | string | "aws-es-proxy-service" | no |
 | aws-es-proxy-replica-count | Number of es proxy replicas  | string | `1` | no |
 | s3_manual_snapshot_repository | ARN of S3 bucket to use for manual snapshot repository  | string | | no |
 | encryption_at_rest | Whether to encrypt the domain at rest | string | false | no |

--- a/main.tf
+++ b/main.tf
@@ -304,7 +304,7 @@ resource "kubernetes_deployment" "aws-es-proxy" {
   count = var.enabled == "true" ? 1 : 0
 
   metadata {
-    name      = "aws-es-proxy"
+    name      = "aws-es-proxy-${local.identifier}"
     namespace = var.namespace
 
     labels = {
@@ -317,14 +317,14 @@ resource "kubernetes_deployment" "aws-es-proxy" {
 
     selector {
       match_labels = {
-        app = "aws-es-proxy"
+        app = "aws-es-proxy-${local.identifier}"
       }
     }
 
     template {
       metadata {
         labels = {
-          app = "aws-es-proxy"
+          app = "aws-es-proxy-${local.identifier}"
         }
 
         annotations = {
@@ -355,13 +355,13 @@ resource "kubernetes_service" "aws-es-proxy-service" {
   count = var.enabled == "true" ? 1 : 0
 
   metadata {
-    name      = "aws-es-proxy-service"
+    name      = var.aws_es_proxy_service_name
     namespace = var.namespace
   }
 
   spec {
     selector = {
-      app = "aws-es-proxy"
+      app = "aws-es-proxy-${local.identifier}"
     }
 
     port {

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,8 @@ resource "random_id" "id" {
 }
 
 locals {
-  identifier = "cloud-platform-${random_id.id.hex}"
+  identifier                = "cloud-platform-${random_id.id.hex}"
+  elasticsearch_domain_name = "${var.team_name}-${var.environment-name}-${var.elasticsearch-domain}"
 }
 
 resource "aws_security_group" "security_group" {
@@ -206,7 +207,7 @@ resource "aws_kms_alias" "alias" {
 
 resource "aws_elasticsearch_domain" "elasticsearch_domain" {
   count                 = var.enabled == "true" ? 1 : 0
-  domain_name           = var.elasticsearch_domain_name
+  domain_name           = local.elasticsearch_domain_name
   elasticsearch_version = var.elasticsearch_version
   advanced_options      = var.advanced_options
 
@@ -296,7 +297,7 @@ data "aws_iam_policy_document" "iam_role_policy" {
 
 resource "aws_elasticsearch_domain_policy" "domain_policy" {
   count           = var.enabled == "true" ? 1 : 0
-  domain_name     = var.elasticsearch_domain_name
+  domain_name     = local.elasticsearch_domain_name
   access_policies = join("", data.aws_iam_policy_document.iam_role_policy.*.json)
 }
 

--- a/main.tf
+++ b/main.tf
@@ -178,11 +178,12 @@ resource "aws_iam_role_policy" "snapshot_role_policy" {
   policy = data.aws_iam_policy_document.snapshot_role_policy[0].json
 }
 
-#resource "null_resource" "es_ns_annotation" {
-#  provisioner "local-exec" {
-#    command = "kubectl annotate namespace ${var.namespace} 'iam.amazonaws.com/permitted=${local.identifier}' --overwrite"
-#  }
-#}
+resource "null_resource" "es_ns_annotation" {
+  count = var.es_ns_annotation ? 1 : 0
+  provisioner "local-exec" {
+    command = "kubectl annotate namespace ${var.namespace} 'iam.amazonaws.com/permitted=${local.identifier}' --overwrite"
+  }
+}
 
 resource "aws_kms_key" "kms" {
   count       = var.encryption_at_rest ? 1 : 0

--- a/main.tf
+++ b/main.tf
@@ -206,7 +206,7 @@ resource "aws_kms_alias" "alias" {
 
 resource "aws_elasticsearch_domain" "elasticsearch_domain" {
   count                 = var.enabled == "true" ? 1 : 0
-  domain_name           = "${var.team_name}-${var.environment-name}-${var.elasticsearch-domain}"
+  domain_name           = var.elasticsearch_domain_name
   elasticsearch_version = var.elasticsearch_version
   advanced_options      = var.advanced_options
 

--- a/main.tf
+++ b/main.tf
@@ -296,7 +296,7 @@ data "aws_iam_policy_document" "iam_role_policy" {
 
 resource "aws_elasticsearch_domain_policy" "domain_policy" {
   count           = var.enabled == "true" ? 1 : 0
-  domain_name     = "${var.team_name}-${var.environment-name}-${var.elasticsearch-domain}"
+  domain_name     = var.elasticsearch_domain_name
   access_policies = join("", data.aws_iam_policy_document.iam_role_policy.*.json)
 }
 

--- a/main.tf
+++ b/main.tf
@@ -178,11 +178,11 @@ resource "aws_iam_role_policy" "snapshot_role_policy" {
   policy = data.aws_iam_policy_document.snapshot_role_policy[0].json
 }
 
-resource "null_resource" "es_ns_annotation" {
-  provisioner "local-exec" {
-    command = "kubectl annotate namespace ${var.namespace} 'iam.amazonaws.com/permitted=${local.identifier}' --overwrite"
-  }
-}
+#resource "null_resource" "es_ns_annotation" {
+#  provisioner "local-exec" {
+#    command = "kubectl annotate namespace ${var.namespace} 'iam.amazonaws.com/permitted=${local.identifier}' --overwrite"
+#  }
+#}
 
 resource "aws_kms_key" "kms" {
   count       = var.encryption_at_rest ? 1 : 0

--- a/output.tf
+++ b/output.tf
@@ -1,3 +1,8 @@
+output "aws_es_proxy_url" {
+  description = "URL for aws-es-proxy service"
+  value       = "http://${kubernetes_service.aws-es-proxy-service.metadata.0.name}:${kubernetes_service.aws-es-proxy-service.port.0.port}"
+}
+
 output "snapshot_role_arn" {
   description = "Snapshot role ARN"
   value       = length(aws_iam_role.snapshot_role) > 0 ? aws_iam_role.snapshot_role[0].arn : null

--- a/output.tf
+++ b/output.tf
@@ -1,6 +1,6 @@
 output "aws_es_proxy_url" {
   description = "URL for aws-es-proxy service"
-  value       = "http://${kubernetes_service.aws-es-proxy-service.metadata.0.name}:${kubernetes_service.aws-es-proxy-service.port.0.port}"
+  value       = length(kubernetes_service.aws-es-proxy-service) > 0 ? "http://${kubernetes_service.aws-es-proxy-service.0.metadata.0.name}:${kubernetes_service.aws-es-proxy-service.0.spec.0.port.0.port}" : ""
 }
 
 output "snapshot_role_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -44,6 +44,12 @@ variable "namespace" {
   description = "Namespace from which the module is requested"
 }
 
+variable "es_ns_annotation" {
+  type        = bool
+  default     = true
+  description = "Whether to add namespace annotation for permitted KIAM role - disable this if running more than one instance of ES in a namespace and the annotation will need to fixed manually."
+}
+
 variable "enabled" {
   type        = string
   default     = "true"

--- a/variables.tf
+++ b/variables.tf
@@ -50,12 +50,6 @@ variable "enabled" {
   description = "Set to false to prevent the module from creating any resources"
 }
 
-variable "elasticsearch_domain_name" {
-  type        = string
-  default     = "${var.team_name}-${var.environment-name}-${var.elasticsearch-domain}"
-  description = "Name of elasticsearch domain"
-}
-
 variable "elasticsearch_version" {
   type        = string
   default     = "7.1"

--- a/variables.tf
+++ b/variables.tf
@@ -50,6 +50,12 @@ variable "enabled" {
   description = "Set to false to prevent the module from creating any resources"
 }
 
+variable "elasticsearch_domain_name" {
+  type        = string
+  default     = "${var.team_name}-${var.environment-name}-${var.elasticsearch-domain}"
+  description = "Name of elasticsearch domain"
+}
+
 variable "elasticsearch_version" {
   type        = string
   default     = "7.1"

--- a/variables.tf
+++ b/variables.tf
@@ -170,6 +170,12 @@ variable "encryption_at_rest" {
   description = "Whether to encrypt the domain at rest"
 }
 
+variable "aws_es_proxy_service_name" {
+  type        = string
+  default     = "aws-es-proxy-service"
+  description = "Name used by aws-es-proxy service"
+}
+
 variable "aws-es-proxy-replica-count" {
   type        = number
   default     = 1


### PR DESCRIPTION
This fix allows for running more than one instance of aws_es_proxy in  a single namespace