### PR TITLE
Fix interpolation expression for resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -101,7 +101,7 @@ data "aws_iam_policy_document" "elasticsearch_role_snapshot_policy" {
       "iam:PassRole"
     ]
 
-    resources = ["${aws_iam_role.snapshot_role[0].arn}"]
+    resources = [aws_iam_role.snapshot_role[0].arn]
   }
 }
 
@@ -156,7 +156,7 @@ data "aws_iam_policy_document" "snapshot_role_policy" {
       "s3:ListBucket"
     ]
 
-    resources = ["${var.s3_manual_snapshot_repository}"]
+    resources = [var.s3_manual_snapshot_repository]
   }
 
   statement {


### PR DESCRIPTION
Interpolation-only expressions are deprecated in terraform 0.11 and throws an warning when during terraform plan. This PR fixes the expression and hence fix the warning.

Related to: https://github.com/ministryofjustice/cloud-platform/issues/2747