### PR TITLE
Use "aws_eks_cluster" replacing data "terraform_remote_state"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,16 +8,8 @@ data "aws_vpc" "selected" {
   }
 }
 
-# This needs to be replaced, once this issue(https://github.com/hashicorp/terraform-provider-aws/issues/13719) is fixed.
-data "terraform_remote_state" "cluster" {
-  count   = var.irsa_enabled == "true" ? 1 : 0
-  backend = "s3"
-
-  config = {
-    bucket = "cloud-platform-terraform-state"
-    region = "eu-west-1"
-    key    = "aws-accounts/cloud-platform-aws/vpc/eks/live/terraform.tfstate"
-  }
+data "aws_eks_cluster" "live" {
+  name = "live"
 }
 
 data "aws_route53_zone" "selected" {
@@ -46,7 +38,7 @@ locals {
   elasticsearch_domain_name    = "${var.team_name}-${var.environment-name}-${var.elasticsearch-domain}"
   aws_es_irsa_sa_name          = var.irsa_enabled ? var.aws_es_irsa_sa_name : null
   assume_role_name             = var.assume_enabled ? local.identifier : null
-  eks_cluster_oidc_issuer_url  = var.irsa_enabled ? data.terraform_remote_state.cluster[0].outputs.cluster_oidc_issuer_url : null
+  eks_cluster_oidc_issuer_url  = var.irsa_enabled ? data.aws_eks_cluster.live.identity.oidc.issuer : null
   es_domain_policy_identifiers = var.assume_enabled ? aws_iam_role.elasticsearch_role[0].arn : module.iam_assumable_role_irsa_elastic_search.this_iam_role_arn
 }
 

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ locals {
   elasticsearch_domain_name    = "${var.team_name}-${var.environment-name}-${var.elasticsearch-domain}"
   aws_es_irsa_sa_name          = var.irsa_enabled ? var.aws_es_irsa_sa_name : null
   assume_role_name             = var.assume_enabled ? local.identifier : null
-  eks_cluster_oidc_issuer_url  = var.irsa_enabled ? data.aws_eks_cluster.live.identity.oidc.issuer : null
+  eks_cluster_oidc_issuer_url  = var.irsa_enabled ? data.aws_eks_cluster.live.identity[0].oidc[0].issuer : null
   es_domain_policy_identifiers = var.assume_enabled ? aws_iam_role.elasticsearch_role[0].arn : module.iam_assumable_role_irsa_elastic_search.this_iam_role_arn
 }
 

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ data "terraform_remote_state" "cluster" {
   config = {
     bucket = "cloud-platform-terraform-state"
     region = "eu-west-1"
-    key    = "aws-accounts/cloud-platform-aws/vpc/eks/${var.cluster_name}/terraform.tfstate"
+    key    = "aws-accounts/cloud-platform-aws/vpc/eks/live/terraform.tfstate"
   }
 }
 


### PR DESCRIPTION
This is to fix Error: Unable to find remote state.

Now we have data "aws_eks_cluster" available to get the cluster issuer value, this will  replace using data "terraform_remote_state"