### PR TITLE
kiam role existence during migration, add delay

### DIFF
--- a/es-proxy.tf
+++ b/es-proxy.tf
@@ -37,8 +37,8 @@ resource "kubernetes_deployment" "aws-es-proxy" {
           name  = "aws-es-proxy"
           security_context {
             allow_privilege_escalation = false
-            run_as_non_root = true
-            run_as_user = 10001
+            run_as_non_root            = true
+            run_as_user                = 10001
           }
           port {
             container_port = 9200

--- a/kiam.tf
+++ b/kiam.tf
@@ -2,7 +2,6 @@
 
 # Role that pods can assume for access to elasticsearch and kibana
 resource "aws_iam_role" "elasticsearch_role" {
-  count              = var.assume_enabled == "true" ? 1 : 0
   name               = local.identifier
   description        = "IAM Role to assume to access the Elasticsearch -${var.elasticsearch-domain} cluster"
   assume_role_policy = join("", data.aws_iam_policy_document.assume_role.*.json)
@@ -19,7 +18,6 @@ resource "aws_iam_role" "elasticsearch_role" {
 }
 
 data "aws_iam_policy_document" "assume_role" {
-  count = var.assume_enabled == "true" ? 1 : 0
 
   statement {
     actions = [
@@ -39,8 +37,7 @@ data "aws_iam_policy_document" "empty" {
 }
 
 resource "aws_iam_role_policy" "elasticsearch_role_policy" {
-  count  = var.assume_enabled == "true" ? 1 : 0
   name   = local.identifier
-  role   = aws_iam_role.elasticsearch_role[0].id
+  role   = aws_iam_role.elasticsearch_role.id
   policy = data.aws_iam_policy_document.elasticsearch_role_policy.json
 }

--- a/main.tf
+++ b/main.tf
@@ -39,8 +39,9 @@ locals {
   aws_es_irsa_sa_name                 = var.irsa_enabled ? var.aws_es_irsa_sa_name : null
   assume_role_name                    = var.assume_enabled ? local.identifier : null
   eks_cluster_oidc_issuer_url         = var.irsa_enabled ? data.aws_eks_cluster.live.identity[0].oidc[0].issuer : null
-  es_domain_policy_identifiers = tolist([aws_iam_role.elasticsearch_role.arn, module.iam_assumable_role_irsa_elastic_search.this_iam_role_arn])
+  es_domain_policy_identifiers = var.assume_enabled ? aws_iam_role.elasticsearch_role.arn : tolist([aws_iam_role.elasticsearch_role.arn, module.iam_assumable_role_irsa_elastic_search.this_iam_role_arn])
 }
+
 
 resource "aws_security_group" "security_group" {
   name        = local.identifier

--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ locals {
   aws_es_irsa_sa_name                 = var.irsa_enabled ? var.aws_es_irsa_sa_name : null
   assume_role_name                    = var.assume_enabled ? local.identifier : null
   eks_cluster_oidc_issuer_url         = var.irsa_enabled ? data.aws_eks_cluster.live.identity[0].oidc[0].issuer : null
-  es_domain_policy_identifiers = var.assume_enabled ? aws_iam_role.elasticsearch_role.arn : tolist([aws_iam_role.elasticsearch_role.arn, module.iam_assumable_role_irsa_elastic_search.this_iam_role_arn])
+  es_domain_policy_identifiers = var.assume_enabled ? tolist([aws_iam_role.elasticsearch_role.arn]) : tolist([aws_iam_role.elasticsearch_role.arn, module.iam_assumable_role_irsa_elastic_search.this_iam_role_arn])
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -266,7 +266,18 @@ data "aws_iam_policy_document" "iam_role_policy" {
   }
 }
 
+resource "time_sleep" "irsa_role_arn_creation" {
+  create_duration = "10s"
+
+  triggers = {
+    # This sets up a proper dependency on the irsa service link role arn creation
+    role_arn = module.iam_assumable_role_irsa_elastic_search.this_iam_role_arn
+  }
+}
+
+
 resource "aws_elasticsearch_domain_policy" "domain_policy" {
+  depends_on = [time_sleep.irsa_role_arn_creation]
   domain_name     = local.elasticsearch_domain_name
   access_policies = join("", data.aws_iam_policy_document.iam_role_policy.*.json)
 }

--- a/main.tf
+++ b/main.tf
@@ -34,12 +34,12 @@ resource "random_id" "id" {
 }
 
 locals {
-  identifier                   = "cloud-platform-${random_id.id.hex}"
-  elasticsearch_domain_name    = "${var.team_name}-${var.environment-name}-${var.elasticsearch-domain}"
-  aws_es_irsa_sa_name          = var.irsa_enabled ? var.aws_es_irsa_sa_name : null
-  assume_role_name             = var.assume_enabled ? local.identifier : null
-  eks_cluster_oidc_issuer_url  = var.irsa_enabled ? data.aws_eks_cluster.live.identity[0].oidc[0].issuer : null
-  es_domain_policy_identifiers = var.assume_enabled ? aws_iam_role.elasticsearch_role[0].arn : module.iam_assumable_role_irsa_elastic_search.this_iam_role_arn
+  identifier                          = "cloud-platform-${random_id.id.hex}"
+  elasticsearch_domain_name           = "${var.team_name}-${var.environment-name}-${var.elasticsearch-domain}"
+  aws_es_irsa_sa_name                 = var.irsa_enabled ? var.aws_es_irsa_sa_name : null
+  assume_role_name                    = var.assume_enabled ? local.identifier : null
+  eks_cluster_oidc_issuer_url         = var.irsa_enabled ? data.aws_eks_cluster.live.identity[0].oidc[0].issuer : null
+  es_domain_policy_identifiers = tolist([aws_iam_role.elasticsearch_role.arn, module.iam_assumable_role_irsa_elastic_search.this_iam_role_arn])
 }
 
 resource "aws_security_group" "security_group" {
@@ -256,7 +256,7 @@ data "aws_iam_policy_document" "iam_role_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = [local.es_domain_policy_identifiers]
+      identifiers = local.es_domain_policy_identifiers
     }
 
     resources = [

--- a/output.tf
+++ b/output.tf
@@ -10,5 +10,5 @@ output "snapshot_role_arn" {
 
 output "aws_iam_role_name" {
   description = "IAM role name to assume when accessing the Elasticsearch"
-  value       = length(aws_iam_role.elasticsearch_role) > 0 ? aws_iam_role.elasticsearch_role[0].name : null
+  value       = length(aws_iam_role.elasticsearch_role) > 0 ? aws_iam_role.elasticsearch_role.name : null
 }


### PR DESCRIPTION
This PR  related to: https://github.com/ministryofjustice/cloud-platform/issues/3353

- stop removing the kiam role creation when migrating from `live-1` to `live` allowing users to access the ES from both the clusters

- add delay to updating domain policy to wait for the irsa role arn to be generated
