### PR TITLE
Format Terraform module using the standard convention, give provider minimum versions, update var types

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,10 +34,10 @@ resource "random_id" "id" {
 }
 
 locals {
-  identifier                          = "cloud-platform-${random_id.id.hex}"
-  elasticsearch_domain_name           = "${var.team_name}-${var.environment-name}-${var.elasticsearch-domain}"
-  aws_es_irsa_sa_name                 = var.aws_es_irsa_sa_name
-  eks_cluster_oidc_issuer_url         = data.aws_eks_cluster.live.identity[0].oidc[0].issuer
+  identifier                   = "cloud-platform-${random_id.id.hex}"
+  elasticsearch_domain_name    = "${var.team_name}-${var.environment-name}-${var.elasticsearch-domain}"
+  aws_es_irsa_sa_name          = var.aws_es_irsa_sa_name
+  eks_cluster_oidc_issuer_url  = data.aws_eks_cluster.live.identity[0].oidc[0].issuer
   es_domain_policy_identifiers = module.iam_assumable_role_irsa_elastic_search.this_iam_role_arn
 }
 
@@ -279,7 +279,7 @@ resource "time_sleep" "irsa_role_arn_creation" {
 
 
 resource "aws_elasticsearch_domain_policy" "domain_policy" {
-  depends_on = [time_sleep.irsa_role_arn_creation]
+  depends_on      = [time_sleep.irsa_role_arn_creation]
   domain_name     = local.elasticsearch_domain_name
   access_policies = join("", data.aws_iam_policy_document.iam_role_policy.*.json)
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,10 +1,9 @@
 output "aws_es_proxy_url" {
   description = "URL for aws-es-proxy service"
-  value       = length(kubernetes_service.aws-es-proxy-service) > 0 ? "http://${kubernetes_service.aws-es-proxy-service.metadata.0.name}:${kubernetes_service.aws-es-proxy-service.spec.0.port.0.port}" : ""
+  value       = length(kubernetes_service.aws-es-proxy-service) > 0 ? "http://${kubernetes_service.aws-es-proxy-service.metadata[0].name}:${kubernetes_service.aws-es-proxy-service.spec[0].port[0].port}" : ""
 }
 
 output "snapshot_role_arn" {
   description = "Snapshot role ARN"
   value       = length(aws_iam_role.snapshot_role) > 0 ? aws_iam_role.snapshot_role[0].arn : null
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -1,45 +1,49 @@
-variable "aws_region" {
-  description = "Region into which the resource will be created."
-  default     = "eu-west-2"
-}
-
 variable "cluster_name" {
   description = "The name of the cluster (eg.: cloud-platform-live-0)"
+  type        = string
 }
 
 variable "team_name" {
   description = "The name of your development team"
+  type        = string
 }
 
 variable "environment-name" {
   description = "The type of environment you're deploying to."
+  type        = string
 }
 
 variable "application" {
   description = "The name of the application which uses this module."
+  type        = string
 }
 
 variable "elasticsearch-domain" {
   description = "The name of the domain you want to use. The actual domain name will use the format <team_name>-<environment-name>-<elasticsearch-domain>"
+  type        = string
 }
 
 variable "is-production" {
-  default = "false"
+  description = "Whether the ElasticSearch cluster is for production use."
+  default     = "false"
+  type        = string
 }
 
 variable "business-unit" {
   description = "Area of the MOJ responsible for the service"
   default     = "mojdigital"
+  type        = string
 }
 
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form <team-name> (<team-email>)"
+  type        = string
 }
 
 variable "namespace" {
   description = "Namespace from which the module is requested"
+  type        = string
 }
-
 
 variable "snapshot_enabled" {
   type        = string
@@ -62,6 +66,7 @@ variable "instance_type" {
 variable "instance_count" {
   description = "Number of data nodes in the cluster"
   default     = 3
+  type        = number
 }
 
 variable "zone_awareness_enabled" {
@@ -73,11 +78,13 @@ variable "zone_awareness_enabled" {
 variable "availability_zone_count" {
   default     = 3
   description = "Number of Availability Zones for the domain to use."
+  type        = number
 }
 
 variable "ebs_volume_size" {
   description = "Optionally use EBS volumes for data storage by specifying volume size in GB"
   default     = 10
+  type        = number
 }
 
 variable "ebs_volume_type" {
@@ -89,6 +96,7 @@ variable "ebs_volume_type" {
 variable "ebs_iops" {
   default     = 0
   description = "The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type"
+  type        = number
 }
 
 variable "log_publishing_index_enabled" {
@@ -130,6 +138,7 @@ variable "log_publishing_application_cloudwatch_log_group_arn" {
 variable "automated_snapshot_start_hour" {
   description = "Hour at which automated snapshots are taken, in UTC"
   default     = 0
+  type        = number
 }
 
 variable "dedicated_master_enabled" {
@@ -141,6 +150,7 @@ variable "dedicated_master_enabled" {
 variable "dedicated_master_count" {
   description = "Number of dedicated master nodes in the cluster"
   default     = 0
+  type        = number
 }
 
 variable "dedicated_master_type" {
@@ -189,10 +199,4 @@ variable "s3_manual_snapshot_repository" {
   type        = string
   default     = ""
   description = "ARN of S3 bucket to use for manual snapshot repository"
-}
-
-variable "eks_cluster_oidc_issuer_url" {
-  description = "If enable_irsa variable is set to true this is going to be used when we create the IAM OIDC role"
-  type        = string
-  default     = ""
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,14 +1,22 @@
 terraform {
+  required_version = ">= 0.14"
+
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 3.0.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.0.0"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
+      version = ">= 3.0.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.7.0"
     }
   }
-  required_version = ">= 0.13"
 }


### PR DESCRIPTION
This PR does the following:

- updates the module to use traditional square brackets to access list items by index rather than the legacy dot syntax
- removes unused variable `aws_region` (you should use a regioned provider declaration to create the resource in a different region)
- removes unused variable `eks_cluster_oidc_issuer_url`
- adds missing variable types and missing variable descriptions
- gives defined providers a minimum version
- updates the minimum Terraform version to 0.14, in line with other modules
- runs terraform fmt
- renames `output.tf` to `outputs.tf` to follow the [standard module structure](https://www.terraform.io/language/modules/develop/structure)