### PR TITLE
Reduce hashicorp/random version to >=2.0.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.0.0"
+      version = ">= 2.0.0"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
This PR reduces the minimum version of `hashicorp/random` to >= 2.0.0, as other modules require <3.0.0.