### PR TITLE
Add domain_endpoint_options: enforce HTTP, use TLS 1.2 if true

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ For the most basic setup, see [the example](example/) folder. Also check the *Ac
 | <a name="input_dedicated_master_enabled"></a> [dedicated\_master\_enabled](#input\_dedicated\_master\_enabled) | Indicates whether dedicated master nodes are enabled for the cluster | `string` | `"false"` | no |
 | <a name="input_dedicated_master_type"></a> [dedicated\_master\_type](#input\_dedicated\_master\_type) | Instance type of the dedicated master nodes in the cluster | `string` | `"t3.small.elasticsearch"` | no |
 | <a name="input_delete_transition"></a> [delete\_transition](#input\_delete\_transition) | Time until indexes are permanently deleted | `string` | `"365d"` | no |
+| <a name="input_domain_endpoint_enforce_https"></a> [domain\_endpoint\_enforce\_https](#input\_domain\_endpoint\_enforce\_https) | Enforce HTTPS when connecting to the cluster's domain endpoint | `bool` | `false` | no |
 | <a name="input_ebs_iops"></a> [ebs\_iops](#input\_ebs\_iops) | The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type | `number` | `3000` | no |
 | <a name="input_ebs_volume_size"></a> [ebs\_volume\_size](#input\_ebs\_volume\_size) | Optionally use EBS volumes for data storage by specifying volume size in GB | `number` | `10` | no |
 | <a name="input_ebs_volume_type"></a> [ebs\_volume\_type](#input\_ebs\_volume\_type) | Storage type of EBS volumes | `string` | `"gp3"` | no |

--- a/main.tf
+++ b/main.tf
@@ -211,6 +211,11 @@ resource "aws_elasticsearch_domain" "elasticsearch_domain" {
     }
   }
 
+  domain_endpoint_options {
+    enforce_https       = var.domain_endpoint_enforce_https
+    tls_security_policy = var.domain_endpoint_enforce_https == true ? "Policy-Min-TLS-1-2-2019-07" : null
+  }
+
   vpc_options {
     security_group_ids = [aws_security_group.security_group.id]
     subnet_ids         = data.aws_subnets.private.ids

--- a/variables.tf
+++ b/variables.tf
@@ -259,3 +259,9 @@ variable "s3_manual_snapshot_repository" {
   default     = ""
   description = "ARN of S3 bucket to use for manual snapshot repository"
 }
+
+variable "domain_endpoint_enforce_https" {
+  type        = bool
+  default     = false
+  description = "Enforce HTTPS when connecting to the cluster's domain endpoint"
+}


### PR DESCRIPTION
This PR will allow consumers to set the [domain endpoint option "enforce HTTPS"](https://aws.amazon.com/about-aws/whats-new/2019/10/amazon-elasticsearch-service-provides-option-to-mandate-https/), which when enabled will automatically use a min. TLS1.2 policy.

This is a two-way thing, where an app may already use HTTPS anyway, but this just enforces it (i.e. redirects or drops a call to the endpoint if using HTTP).