### PR TITLE
Enable   domain_endpoint_enforce_https for 7.10

### DIFF
--- a/example/elasticsearch.tf
+++ b/example/elasticsearch.tf
@@ -22,6 +22,7 @@ module "example_team_es" {
 
   # change the elasticsearch version as you see fit.
   elasticsearch_version = "7.10"
+  domain_endpoint_enforce_https   = true
 
   # This will enable creation of manual snapshot in s3 repo, provide the "s3 bucket arn" to create snapshot in s3.
   # s3_manual_snapshot_repository = "s3-bucket-arn"


### PR DESCRIPTION
For 7.10 if the   domain_endpoint_enforce_https  is not set to true, terraform apply errors 

 ValidationException: 1 validation error detected: Value '' at 'domainEndpointOptions.tLSSecurityPolicy' failed to satisfy constraint: Member must satisfy enum value set: [Policy-Min-TLS-1-0-2019-07, Policy-Min-TLS-1-2-2019-07]