### PR TITLE
Fix domain_name no more than 28 characters long

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ resource "random_id" "id" {
 
 locals {
   identifier                   = "cloud-platform-${random_id.id.hex}"
-  elasticsearch_domain_name    = "${var.team_name}-${var.environment-name}-${var.elasticsearch-domain}"
+  elasticsearch_domain_name    = length("${var.team_name}-${var.environment-name}-${var.elasticsearch-domain}") < 28 ? "${var.team_name}-${var.environment-name}-${var.elasticsearch-domain}" : var.elasticsearch-domain
   aws_es_irsa_sa_name          = var.aws_es_irsa_sa_name
   eks_cluster_oidc_issuer_url  = data.aws_eks_cluster.eks_cluster.identity[0].oidc[0].issuer
   es_domain_policy_identifiers = module.iam_assumable_role_irsa_elastic_search.this_iam_role_arn
@@ -171,7 +171,7 @@ resource "aws_kms_alias" "alias" {
 }
 
 resource "aws_elasticsearch_domain" "elasticsearch_domain" {
-  domain_name           = local.elasticsearch_domain_name
+  domain_name           = length(local.elasticsearch_domain_name) > 28  
   elasticsearch_version = var.elasticsearch_version
   advanced_options = merge({
     "rest.action.multi.allow_explicit_index" = "true"

--- a/main.tf
+++ b/main.tf
@@ -171,7 +171,7 @@ resource "aws_kms_alias" "alias" {
 }
 
 resource "aws_elasticsearch_domain" "elasticsearch_domain" {
-  domain_name           = length(local.elasticsearch_domain_name) > 28  
+  domain_name           = local.elasticsearch_domain_name
   elasticsearch_version = var.elasticsearch_version
   advanced_options = merge({
     "rest.action.multi.allow_explicit_index" = "true"


### PR DESCRIPTION
Use the length function to identify the characters used. 

The actual domain name will use the format <team_name>-<environment-name>-<elasticsearch-domain>

If the actual domain name is > 28 use var.elasticsearch-domain